### PR TITLE
Bump nnichols/clojure-dependency-update-action to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Unlike other Wall Brew repositories, `rebroadcast` does not use semantic version
 Since `rebroadcast` primarily supports automated actions and developer tooling, there is little to distinguish breaking changes and bug fixes.
 That said, it is important to track the history of changes made to our CI/CD and documentation over time.
 
+## 2023 Apr 01
+
+* Bump `nnichols/clojure-dependency-update-action` to `v5`
+
 ## 2023 Mar 27
 
 * Bump `actions/checkout` to `3.5.0`

--- a/sources/github-actions/workflows/dependencies.yml
+++ b/sources/github-actions/workflows/dependencies.yml
@@ -25,7 +25,7 @@ jobs:
             ${{ runner.os }}-clj
 
     - name: Check Dependencies
-      uses: nnichols/clojure-dependency-update-action@v4
+      uses: nnichols/clojure-dependency-update-action@v5
       with:
         github-token: ${{ secrets.WALL_BREW_BOT_PAT }}
         git-email: the.wall.brew@gmail.com


### PR DESCRIPTION
https://github.com/nnichols/clojure-dependency-update-action/releases/tag/v5