### PR TITLE
Narrow cljstyle targets

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,3 +19,4 @@ jobs:
           reporter: github-pr-review
           level: error
           filter_mode: file
+          ignore: "litre,millilitre,litres,millilitres"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Unlike other Wall Brew repositories, `rebroadcast` does not use semantic version
 Since `rebroadcast` primarily supports automated actions and developer tooling, there is little to distinguish breaking changes and bug fixes.
 That said, it is important to track the history of changes made to our CI/CD and documentation over time.
 
+## 2024 March 3
+
+* Update `.cljstyle` config to ignore commonly uncommitted directories (e.g. `node_modules`, `target`)
+* Update Misspell to ignore alternative spellings of "liter" and "milliliter"
+* Update `sealog` config to pretty print changelog entry source files
+
 ## 2024 February 19
 
 * Add default configuration for [Sealog](https://github.com/Wall-Brew-Co/lein-sealog)

--- a/sources/clojure/.cljstyle
+++ b/sources/clojure/.cljstyle
@@ -1,2 +1,3 @@
-{:files {:extensions #{"clj" "cljs" "cljc" "cljx" "edn"}}
+{:files {:extensions #{"clj" "cljs" "cljc" "cljx" "edn"}
+         :ignore     #{"target" ".git" ".idea" ".vscode" "node_modules"}}
  :rules {:namespaces {:enabled? false}}}

--- a/sources/clojure/sealog/config.edn
+++ b/sources/clojure/sealog/config.edn
@@ -1,3 +1,4 @@
 {:changelog-filename        "CHANGELOG.md"
  :changelog-entry-directory ".sealog/changes/"
- :version-scheme            :semver3}
+ :version-scheme            :semver3
+ :pretty-print-edn?         true}

--- a/sources/github-actions/workflows/lint.yml
+++ b/sources/github-actions/workflows/lint.yml
@@ -19,6 +19,8 @@ jobs:
           reporter: github-pr-review
           level: error
           filter_mode: file
+          ignore: "litre,millilitre,litres,millilitres"
+          # Brewing applications support both US and non-US English
 
   clj-kondo:
     runs-on: ubuntu-latest


### PR DESCRIPTION
* Update `.cljstyle` config to ignore commonly uncommitted directories (e.g. `node_modules`, `target`)
* Update Misspell to ignore alternative spellings of "liter" and "milliliter"
* Update `sealog` config to pretty print changelog entry source files