### PR TITLE
Pin all actions by SHA

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,18 @@
   "commitBodyTable": true,
   "configMigration": true,
   "configWarningReuseIssue": false,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^sources/github-actions/workflows/.+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+[A-Za-z0-9_.-]+:\\s*['\"]?(?<currentValue>[^'\"\\s]+)['\"]?"
+      ],
+      "extractVersion": "^v?(?<version>.+)$"
+    }
+  ],
   "extends": [
     "config:recommended"
   ],

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,6 +3,9 @@ name: Formatter
 on:
   pull_request: {}
 
+permissions:
+  contents: write
+
 jobs:
   formatting:
     # This job requires the Wall Brew Bot Token, so it is only run on non-forked repositories
@@ -10,14 +13,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # https://github.com/actions/checkout
       - name: git checkout
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.WALL_BREW_BOT_PAT }}
 
+      # https://github.com/actions/setup-node
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: 'npm'
@@ -29,8 +34,9 @@ jobs:
       - name: Update Markdown Files
         run: doctoc sources/community/CODE_OF_CONDUCT.md README.md CHANGELOG.md sources/templates/CONTRIBUTING.md --github
 
+      # https://github.com/stefanzweifel/git-auto-commit-action
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7.1.0
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
           commit_message: |
             [Format] Auto-formatting

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -2,6 +2,10 @@ name: Label Pull Requests
 
 on: [pull_request]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   label:
 
@@ -14,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/labeler@v6
+    # https://github.com/actions/labeler
+    - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
       with:
         repo-token: "${{ secrets.WALL_BREW_BOT_PAT }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Linter
 on: [pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   spell-check:
 
@@ -13,13 +17,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # https://github.com/actions/checkout
       - name: Checkout Repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.head_ref }}
 
+      # https://github.com/reviewdog/action-misspell
       - name: misspell
-        uses: reviewdog/action-misspell@v1
+        uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962 # v1
         with:
           github_token: ${{ secrets.WALL_BREW_BOT_PAT }}
           locale: "US"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,17 +5,22 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   sync-files:
     # This job requires the Wall Brew Bot Token, so it is only run on non-forked repositories
     if: github.repository_owner == 'Wall-Brew-Co'
     runs-on: ubuntu-latest
     steps:
+      # https://github.com/actions/checkout
       - name: Checkout latest commit
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      # https://github.com/BetaHuhn/repo-file-sync-action
       - name: Run GitHub File Sync
-        uses: BetaHuhn/repo-file-sync-action@v1.21.1
+        uses: BetaHuhn/repo-file-sync-action@8b92be3375cf1d1b0cd579af488a9255572e4619 # v1.21.1
         with:
           GH_PAT: ${{ secrets.WALL_BREW_BOT_PAT }}
           GIT_EMAIL: the.wall.brew@gmail.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ That said, it is important to track the history of changes made to our CI/CD and
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+- [2026 June 6](#2026-june-6)
 - [2025 January 5](#2025-january-5)
 - [2025 January 3](#2025-january-3)
 - [2025 January 1](#2025-january-1)
@@ -41,6 +42,16 @@ That said, it is important to track the history of changes made to our CI/CD and
 - [2022 December 06](#2022-december-06)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 2026 June 6
+
+- Pin all GitHub Actions to full commit SHAs, retaining version tags as inline comments
+- Add a comment linking to each Action's source repository above every workflow step
+- Add least-privilege `permissions` blocks to every workflow
+- Pin `ribtoks/tdg-github-action` to `v0.4.17-beta`, replacing the mutable `master` reference
+- Update the Java distribution from the deprecated `adopt` (AdoptOpenJDK) to `temurin` (Eclipse Temurin)
+- Pin `lein`, `clj-kondo`, and `cljstyle` versions in `setup-clojure` steps, replacing `latest`
+- Add a Renovate `customManagers` rule to keep the pinned `lein`/`clj-kondo`/`cljstyle` versions up to date
 
 ## 2025 January 5
 

--- a/sources/github-actions/workflows/cljdoc_test.yml
+++ b/sources/github-actions/workflows/cljdoc_test.yml
@@ -3,6 +3,9 @@ name: Check cljdoc compatibility
 
 on: ["pull_request", "workflow_dispatch"]
 
+permissions:
+  contents: read
+
 jobs:
   check-cljdoc:
 
@@ -25,29 +28,33 @@ jobs:
         id: echo-git-ref
         run: echo "Using ${{ github.ref }} branch from ${{ github.repository }} repository"
 
+      # https://github.com/actions/checkout
       - name: Checkout Repository
         id: checkout
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      # https://github.com/actions/setup-java
       - name: Setup Java
         id: install-java
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'adopt'
           java-version: '21'
           # This should match system.properties
 
+      # https://github.com/DeLaGuardo/setup-clojure
       - name: Install Leiningen
         id: install-leiningen
-        uses: DeLaGuardo/setup-clojure@13.6.1
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           lein: 'latest'
           clj-kondo: 'latest'
           cljstyle: 'latest'
 
+      # https://github.com/actions/cache
       - name: Cache Maven Dependencies
         id: cache-maven
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         env:
           cache-name: cache-maven
         with:
@@ -68,9 +75,10 @@ jobs:
         id: package
         run: lein jar
 
+      # https://github.com/cljdoc/cljdoc-check-action
       - name: cljdoc Check
         id: cljdoc-check
-        uses: cljdoc/cljdoc-check-action@v0.0.3
+        uses: cljdoc/cljdoc-check-action@e2317d0a99ff9bcfbdde9e734edac1ff62bdc9e6 # v0.0.3
 
       - name: Echo Status
         id: echo-status

--- a/sources/github-actions/workflows/cljdoc_test.yml
+++ b/sources/github-actions/workflows/cljdoc_test.yml
@@ -38,7 +38,7 @@ jobs:
         id: install-java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '21'
           # This should match system.properties
 
@@ -47,9 +47,12 @@ jobs:
         id: install-leiningen
         uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
-          lein: 'latest'
-          clj-kondo: 'latest'
-          cljstyle: 'latest'
+          # renovate: datasource=github-releases depName=technomancy/leiningen
+          lein: '2.12.0'
+          # renovate: datasource=github-releases depName=clj-kondo/clj-kondo versioning=loose
+          clj-kondo: '2026.05.25'
+          # renovate: datasource=github-releases depName=greglook/cljstyle
+          cljstyle: '0.17.642'
 
       # https://github.com/actions/cache
       - name: Cache Maven Dependencies

--- a/sources/github-actions/workflows/clojure.yml
+++ b/sources/github-actions/workflows/clojure.yml
@@ -39,7 +39,7 @@ jobs:
         id: install-java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '21'
           # This should match system.properties
 
@@ -48,9 +48,12 @@ jobs:
         id: install-leiningen
         uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
-          lein: 'latest'
-          clj-kondo: 'latest'
-          cljstyle: 'latest'
+          # renovate: datasource=github-releases depName=technomancy/leiningen
+          lein: '2.12.0'
+          # renovate: datasource=github-releases depName=clj-kondo/clj-kondo versioning=loose
+          clj-kondo: '2026.05.25'
+          # renovate: datasource=github-releases depName=greglook/cljstyle
+          cljstyle: '0.17.642'
 
       # https://github.com/actions/cache
       - name: Cache Maven Dependencies

--- a/sources/github-actions/workflows/clojure.yml
+++ b/sources/github-actions/workflows/clojure.yml
@@ -3,6 +3,9 @@ name: Clojure Tests
 
 on: ["workflow_dispatch", "pull_request"]
 
+permissions:
+  contents: read
+
 jobs:
   test:
 
@@ -26,29 +29,33 @@ jobs:
         id: echo-git-ref
         run: echo "Using ${{ github.ref }} branch from ${{ github.repository }} repository"
 
+      # https://github.com/actions/checkout
       - name: Checkout Repository
         id: checkout
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      # https://github.com/actions/setup-java
       - name: Setup Java
         id: install-java
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'adopt'
           java-version: '21'
           # This should match system.properties
 
+      # https://github.com/DeLaGuardo/setup-clojure
       - name: Install Leiningen
         id: install-leiningen
-        uses: DeLaGuardo/setup-clojure@13.6.1
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           lein: 'latest'
           clj-kondo: 'latest'
           cljstyle: 'latest'
 
+      # https://github.com/actions/cache
       - name: Cache Maven Dependencies
         id: cache-maven
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         env:
           cache-name: cache-maven
         with:

--- a/sources/github-actions/workflows/clojurescript.yml
+++ b/sources/github-actions/workflows/clojurescript.yml
@@ -39,7 +39,7 @@ jobs:
         id: install-java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '21'
           # This should match system.properties
 
@@ -48,9 +48,12 @@ jobs:
         id: install-leiningen
         uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
-          lein: 'latest'
-          clj-kondo: 'latest'
-          cljstyle: 'latest'
+          # renovate: datasource=github-releases depName=technomancy/leiningen
+          lein: '2.12.0'
+          # renovate: datasource=github-releases depName=clj-kondo/clj-kondo versioning=loose
+          clj-kondo: '2026.05.25'
+          # renovate: datasource=github-releases depName=greglook/cljstyle
+          cljstyle: '0.17.642'
 
       # https://github.com/actions/cache
       - name: Cache Maven Dependencies

--- a/sources/github-actions/workflows/clojurescript.yml
+++ b/sources/github-actions/workflows/clojurescript.yml
@@ -3,6 +3,9 @@ name: Clojurescript Tests
 
 on: ["workflow_dispatch", "pull_request"]
 
+permissions:
+  contents: read
+
 jobs:
   test:
 
@@ -26,29 +29,33 @@ jobs:
         id: echo-git-ref
         run: echo "Using ${{ github.ref }} branch from ${{ github.repository }} repository"
 
+      # https://github.com/actions/checkout
       - name: Checkout Repository
         id: checkout
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      # https://github.com/actions/setup-java
       - name: Setup Java
         id: install-java
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'adopt'
           java-version: '21'
           # This should match system.properties
 
+      # https://github.com/DeLaGuardo/setup-clojure
       - name: Install Leiningen
         id: install-leiningen
-        uses: DeLaGuardo/setup-clojure@13.6.1
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           lein: 'latest'
           clj-kondo: 'latest'
           cljstyle: 'latest'
 
+      # https://github.com/actions/cache
       - name: Cache Maven Dependencies
         id: cache-maven
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         env:
           cache-name: cache-maven
         with:
@@ -57,9 +64,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-clj
 
+      # https://github.com/actions/cache
       - name: Cache npm dependencies
         id: cache-npm
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         env:
             cache-name: cache-npm
         with:

--- a/sources/github-actions/workflows/contributors.yml
+++ b/sources/github-actions/workflows/contributors.yml
@@ -9,6 +9,9 @@ on:
       - master
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   contributors:
     # This job requires the Wall Brew Bot Token, so it is only run on non-forked repositories
@@ -27,9 +30,10 @@ jobs:
         id: echo-git-ref
         run: echo "Using ${{ github.ref }} branch from ${{ github.repository }} repository"
 
+      # https://github.com/wow-actions/contributors-list
       - name: Generate Contributors Image
         id: contributors
-        uses: wow-actions/contributors-list@v1
+        uses: wow-actions/contributors-list@b9e91f91a51a55460fdcae64daad0cb8122cdd53 # v1
         with:
           GITHUB_TOKEN: ${{ secrets.WALL_BREW_BOT_PAT }}
           svgPath: CONTRIBUTORS.svg

--- a/sources/github-actions/workflows/deploy_to_clojars.yml
+++ b/sources/github-actions/workflows/deploy_to_clojars.yml
@@ -5,6 +5,8 @@ name: Deploy to Clojars
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 jobs:
   deploy:
@@ -26,29 +28,33 @@ jobs:
         id: echo-git-ref
         run: echo "Using ${{ github.ref }} branch from ${{ github.repository }} repository"
 
+      # https://github.com/actions/checkout
       - name: Checkout Repository
         id: checkout
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      # https://github.com/actions/setup-java
       - name: Setup Java
         id: install-java
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'adopt'
           java-version: '21'
           # This should match system.properties
 
+      # https://github.com/DeLaGuardo/setup-clojure
       - name: Install Leiningen
         id: install-leiningen
-        uses: DeLaGuardo/setup-clojure@13.6.1
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           lein: 'latest'
           clj-kondo: 'latest'
           cljstyle: 'latest'
 
+      # https://github.com/actions/cache
       - name: Cache Maven Dependencies
         id: cache-maven
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         env:
           cache-name: cache-maven
         with:
@@ -99,9 +105,10 @@ jobs:
 
       # Push a tag to the repository to mark the version
       # This also helps Renovate locate Change Notes for dependency update PRs
+      # https://github.com/hole19/git-tag-action
       - name: Push Tag
         id: push-tag
-        uses: hole19/git-tag-action@v1.0
+        uses: hole19/git-tag-action@0b717b660aa3ac0154c5c5e02d6153642cc64966 # v1.0
         env:
           TAG: v${{ steps.versionchk.outputs.VERSION }}
           GITHUB_TOKEN: ${{ secrets.WALL_BREW_BOT_PAT }}

--- a/sources/github-actions/workflows/deploy_to_clojars.yml
+++ b/sources/github-actions/workflows/deploy_to_clojars.yml
@@ -38,7 +38,7 @@ jobs:
         id: install-java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '21'
           # This should match system.properties
 
@@ -47,9 +47,12 @@ jobs:
         id: install-leiningen
         uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
-          lein: 'latest'
-          clj-kondo: 'latest'
-          cljstyle: 'latest'
+          # renovate: datasource=github-releases depName=technomancy/leiningen
+          lein: '2.12.0'
+          # renovate: datasource=github-releases depName=clj-kondo/clj-kondo versioning=loose
+          clj-kondo: '2026.05.25'
+          # renovate: datasource=github-releases depName=greglook/cljstyle
+          cljstyle: '0.17.642'
 
       # https://github.com/actions/cache
       - name: Cache Maven Dependencies

--- a/sources/github-actions/workflows/format.yml
+++ b/sources/github-actions/workflows/format.yml
@@ -42,7 +42,7 @@ jobs:
         id: install-java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '21'
           # This should match system.properties
 
@@ -51,9 +51,12 @@ jobs:
         id: install-leiningen
         uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
-          lein: 'latest'
-          clj-kondo: 'latest'
-          cljstyle: 'latest'
+          # renovate: datasource=github-releases depName=technomancy/leiningen
+          lein: '2.12.0'
+          # renovate: datasource=github-releases depName=clj-kondo/clj-kondo versioning=loose
+          clj-kondo: '2026.05.25'
+          # renovate: datasource=github-releases depName=greglook/cljstyle
+          cljstyle: '0.17.642'
 
       - name: Format Clojure Code
         id: format

--- a/sources/github-actions/workflows/format.yml
+++ b/sources/github-actions/workflows/format.yml
@@ -4,6 +4,9 @@ name: Formatter
 
 on: [pull_request]
 
+permissions:
+  contents: write
+
 jobs:
   formatting:
     # This job requires the Wall Brew Bot Token, so it is only run on non-forked repositories
@@ -26,24 +29,27 @@ jobs:
 
       # Checkout the repository with our Wall Brew Bot Token
       # We need this so any changes can be committed back to the repository
+      # https://github.com/actions/checkout
       - name: Checkout Repository
         id: checkout
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.WALL_BREW_BOT_PAT }}
 
+      # https://github.com/actions/setup-java
       - name: Setup Java
         id: install-java
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'adopt'
           java-version: '21'
           # This should match system.properties
 
+      # https://github.com/DeLaGuardo/setup-clojure
       - name: Install Leiningen
         id: install-leiningen
-        uses: DeLaGuardo/setup-clojure@13.6.1
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           lein: 'latest'
           clj-kondo: 'latest'
@@ -54,9 +60,10 @@ jobs:
         run: |
           cljstyle fix --report --report-timing --verbose
 
+      # https://github.com/stefanzweifel/git-auto-commit-action
       - name: Commit Changes
         id: commit
-        uses: stefanzweifel/git-auto-commit-action@v7.1.0
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
           commit_message: |
             [Format] Auto-formatting

--- a/sources/github-actions/workflows/greetings.yml
+++ b/sources/github-actions/workflows/greetings.yml
@@ -3,6 +3,10 @@ name: Greetings
 
 on: [pull_request, issues]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   greeting:
     # This job requires the Wall Brew Bot Token, so it is only run on non-forked repositories
@@ -21,9 +25,10 @@ jobs:
         id: echo-git-ref
         run: echo "Using ${{ github.ref }} branch from ${{ github.repository }} repository"
 
+      # https://github.com/actions/first-interaction
       - name: Greet New Contributors
         id: greet
-        uses: actions/first-interaction@v3
+        uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3
         with:
           repo_token: ${{ secrets.WALL_BREW_BOT_PAT }}
           issue_message: 'Thank you for taking the time to let us know!'

--- a/sources/github-actions/workflows/label.yml
+++ b/sources/github-actions/workflows/label.yml
@@ -3,6 +3,10 @@ name: Label Pull Requests
 
 on: [pull_request]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   label:
     # This job requires the Wall Brew Bot Token, so it is only run on non-forked repositories
@@ -23,9 +27,10 @@ jobs:
         id: echo-git-ref
         run: echo "Using ${{ github.ref }} branch from ${{ github.repository }} repository"
 
+      # https://github.com/actions/labeler
       - name: Label Pull Requests
         id: label
-        uses: actions/labeler@v6
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
         with:
           repo-token: "${{ secrets.WALL_BREW_BOT_PAT }}"
 

--- a/sources/github-actions/workflows/lint.yml
+++ b/sources/github-actions/workflows/lint.yml
@@ -130,7 +130,7 @@ jobs:
         id: install-java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '21'
           # This should match system.properties
 
@@ -139,9 +139,12 @@ jobs:
         id: install-leiningen
         uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
-          lein: 'latest'
-          clj-kondo: 'latest'
-          cljstyle: 'latest'
+          # renovate: datasource=github-releases depName=technomancy/leiningen
+          lein: '2.12.0'
+          # renovate: datasource=github-releases depName=clj-kondo/clj-kondo versioning=loose
+          clj-kondo: '2026.05.25'
+          # renovate: datasource=github-releases depName=greglook/cljstyle
+          cljstyle: '0.17.642'
 
       # https://github.com/actions/cache
       - name: Cache Maven Dependencies
@@ -200,7 +203,7 @@ jobs:
         id: install-java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '21'
           # This should match system.properties
 
@@ -209,9 +212,12 @@ jobs:
         id: install-leiningen
         uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
-          lein: 'latest'
-          clj-kondo: 'latest'
-          cljstyle: 'latest'
+          # renovate: datasource=github-releases depName=technomancy/leiningen
+          lein: '2.12.0'
+          # renovate: datasource=github-releases depName=clj-kondo/clj-kondo versioning=loose
+          clj-kondo: '2026.05.25'
+          # renovate: datasource=github-releases depName=greglook/cljstyle
+          cljstyle: '0.17.642'
 
       # https://github.com/actions/cache
       - name: Cache Maven Dependencies

--- a/sources/github-actions/workflows/lint.yml
+++ b/sources/github-actions/workflows/lint.yml
@@ -4,10 +4,18 @@ name: Linter
 
 on: ["workflow_dispatch", "pull_request"]
 
+permissions:
+  contents: read
+
 jobs:
   spell-check:
     # This job requires the Wall Brew Bot Token, so it is only run on non-forked repositories
     if: github.repository_owner == 'Wall-Brew-Co'
+
+    # reviewdog posts review comments back to the pull request
+    permissions:
+      contents: read
+      pull-requests: write
 
     runs-on: ubuntu-latest
 
@@ -24,15 +32,17 @@ jobs:
         id: echo-git-ref
         run: echo "Using ${{ github.ref }} branch from ${{ github.repository }} repository"
 
+      # https://github.com/actions/checkout
       - name: Checkout Repository
         id: checkout
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.head_ref }}
 
+      # https://github.com/reviewdog/action-misspell
       - name: Check Spelling
         id: spell-check
-        uses: reviewdog/action-misspell@v1
+        uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962 # v1
         with:
           github_token: ${{ secrets.WALL_BREW_BOT_PAT }}
           locale: "US"
@@ -50,6 +60,11 @@ jobs:
     # This job requires the Wall Brew Bot Token, so it is only run on non-forked repositories
     if: github.repository_owner == 'Wall-Brew-Co'
 
+    # reviewdog posts review comments back to the pull request
+    permissions:
+      contents: read
+      pull-requests: write
+
     runs-on: ubuntu-latest
 
     steps:
@@ -65,15 +80,17 @@ jobs:
         id: echo-git-ref
         run: echo "Using ${{ github.ref }} branch from ${{ github.repository }} repository"
 
+      # https://github.com/actions/checkout
       - name: Checkout Repository
         id: checkout
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.head_ref }}
 
+      # https://github.com/nnichols/clojure-lint-action
       - name: Lint Clojure
         id: clj-kondo
-        uses: nnichols/clojure-lint-action@v9
+        uses: nnichols/clojure-lint-action@300bf4db85ff2b237c3b6dd3a1d3abfaa0f195ed # v9
         with:
           github_token: ${{ secrets.WALL_BREW_BOT_PAT }}
           reporter: github-pr-review
@@ -101,31 +118,35 @@ jobs:
         id: echo-git-ref
         run: echo "Using ${{ github.ref }} branch from ${{ github.repository }} repository"
 
+      # https://github.com/actions/checkout
       - name: Checkout Repository
         id: checkout
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.head_ref }}
 
+      # https://github.com/actions/setup-java
       - name: Setup Java
         id: install-java
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'adopt'
           java-version: '21'
           # This should match system.properties
 
+      # https://github.com/DeLaGuardo/setup-clojure
       - name: Install Leiningen
         id: install-leiningen
-        uses: DeLaGuardo/setup-clojure@13.6.1
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           lein: 'latest'
           clj-kondo: 'latest'
           cljstyle: 'latest'
 
+      # https://github.com/actions/cache
       - name: Cache Maven Dependencies
         id: cache-maven
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         env:
           cache-name: cache-maven
         with:
@@ -167,31 +188,35 @@ jobs:
         id: echo-git-ref
         run: echo "Using ${{ github.ref }} branch from ${{ github.repository }} repository"
 
+      # https://github.com/actions/checkout
       - name: Checkout Repository
         id: checkout
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.head_ref }}
 
+      # https://github.com/actions/setup-java
       - name: Setup Java
         id: install-java
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'adopt'
           java-version: '21'
           # This should match system.properties
 
+      # https://github.com/DeLaGuardo/setup-clojure
       - name: Install Leiningen
         id: install-leiningen
-        uses: DeLaGuardo/setup-clojure@13.6.1
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           lein: 'latest'
           clj-kondo: 'latest'
           cljstyle: 'latest'
 
+      # https://github.com/actions/cache
       - name: Cache Maven Dependencies
         id: cache-maven
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         env:
           cache-name: cache-maven
         with:

--- a/sources/github-actions/workflows/scanner.yml
+++ b/sources/github-actions/workflows/scanner.yml
@@ -35,10 +35,12 @@ jobs:
         id: echo-git-ref
         run: echo "Using ${{ github.ref }} branch from ${{ github.repository }} repository"
 
+      # https://github.com/actions/checkout
       - name: Checkout Repository
         id: checkout
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      # https://github.com/clj-holmes/clj-holmes-action (pinned to the `main` ref; no semver releases are published)
       - name: Scan Code
         id: scan
         uses: clj-holmes/clj-holmes-action@53daa4da4ff495cccf791e4ba4222a8317ddae9e
@@ -47,9 +49,10 @@ jobs:
           output-file: 'clj-holmes-results.sarif'
           fail-on-result: 'false'
 
+      # https://github.com/github/codeql-action
       - name: Upload Analysis Results To GitHub Security Tab
         id: upload-results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: ${{github.workspace}}/clj-holmes-results.sarif
 

--- a/sources/github-actions/workflows/sync_labels.yml
+++ b/sources/github-actions/workflows/sync_labels.yml
@@ -8,6 +8,11 @@ on:
     paths:
       - .github/labels.yml
 
+# action-label-syncer manages repository labels via the GITHUB_TOKEN
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   label-sync:
     runs-on: ubuntu-latest
@@ -25,13 +30,15 @@ jobs:
         id: echo-git-ref
         run: echo "Using ${{ github.ref }} branch from ${{ github.repository }} repository"
 
+      # https://github.com/actions/checkout
       - name: Checkout Repository
         id: checkout
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      # https://github.com/micnncim/action-label-syncer
       - name: Synchronize Labels
         id: sync-labels
-        uses: micnncim/action-label-syncer@v1
+        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/sources/github-actions/workflows/todo.yml
+++ b/sources/github-actions/workflows/todo.yml
@@ -6,6 +6,11 @@ on:
     branches:
     - master
 
+# tdg-github-action opens TODO issues via the GITHUB_TOKEN
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   todo:
 
@@ -24,13 +29,15 @@ jobs:
         id: echo-git-ref
         run: echo "Using ${{ github.ref }} branch from ${{ github.repository }} repository"
 
+      # https://github.com/actions/checkout
       - name: Checkout Repository
         id: checkout
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      # https://github.com/ribtoks/tdg-github-action
       - name: Generate TODO Tickets
         id: todo
-        uses: ribtoks/tdg-github-action@master
+        uses: ribtoks/tdg-github-action@7cc4b6643e790dde39ac8bf2cfc8c08c660afbb2 # v0.4.17-beta
         with:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
# Proposed Changes

Pins every Action to an immutable commit SHA, apply least-privilege token permissions, and pin the Clojure toolchain versions with Renovate tracking. 

- Additions:
  - Per-workflow least-privilege `permissions:` blocks on every workflow
  - A source-repository URL comment above every workflow step's `uses:`
  - A Renovate `customManagers` rule in `.github/renovate.json` to track the pinned `lein`/`clj-kondo`/`cljstyle` versions
  - `## 2026 June 6` CHANGELOG section
- Changes:
  - Pin all GitHub Actions to full commit SHAs, with version tags retained as inline `# vX.Y.Z` comments for Renovate
  - Migrate the Java distribution from `adopt` (AdoptOpenJDK) to `temurin` (Eclipse Temurin)
  - Pin `lein` (`2.12.0`), `clj-kondo` (`2026.05.25`), and `cljstyle` (`0.17.642`) in `setup-clojure` steps
- Deprecations:
  - None
- Removals:
  - Floating `latest` tool versions in `setup-clojure` steps
  - The mutable `ribtoks/tdg-github-action@master` reference (now pinned)
- Fixes:
  - None
- Security:
  - Eliminate mutable Action references (SHA pinning) to close a supply-chain vector — every third-party Action now resolves to an immutable commit
  - Scope each workflow's `GITHUB_TOKEN` to the minimum permissions it needs
  - Move off the unmaintained AdoptOpenJDK line, which no longer receives security updates

## Reviewer notes

- **Behavior changes to be aware of:**
  - `ribtoks/tdg-github-action` was floating on `master`; it is now pinned to `v0.4.17-beta` (its latest release — all releases are `-beta`).
  - `clj-holmes/clj-holmes-action` has no semver releases; its existing SHA (tracking the `main` ref) is preserved with a URL comment only.
  - Tool versions no longer auto-track `latest`; the new Renovate `customManagers` rule bumps them centrally instead.
- **The customManager lives only in rebroadcast's own `.github/renovate.json`**, not the distributed `sources/github-actions/renovate.json`, mirroring the existing `github-actions: { enabled: false }` split so consumer repos stay frozen and receive changes via sync.

## Pre-merge Checklist

- [x] Read and agree to the Contribution Guidelines and Code of Conduct
- [x] ~~Write new tests for impacted functionality~~ — N/A (no application code)
- [x] Update the CHANGELOG (rebroadcast does not use versioning)
- [x] Confirm README needs no update (distribution scheme unchanged; no Action
      inventory is documented there)
