### PR TITLE
Revert "Update dependency technomancy/leiningen to v2.13.0"

### DIFF
--- a/sources/github-actions/workflows/cljdoc_test.yml
+++ b/sources/github-actions/workflows/cljdoc_test.yml
@@ -48,7 +48,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           # renovate: datasource=github-releases depName=technomancy/leiningen
-          lein: '2.13.0'
+          lein: '2.12.0'
           # renovate: datasource=github-releases depName=clj-kondo/clj-kondo versioning=loose
           clj-kondo: '2026.05.25'
           # renovate: datasource=github-releases depName=greglook/cljstyle

--- a/sources/github-actions/workflows/clojure.yml
+++ b/sources/github-actions/workflows/clojure.yml
@@ -49,7 +49,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           # renovate: datasource=github-releases depName=technomancy/leiningen
-          lein: '2.13.0'
+          lein: '2.12.0'
           # renovate: datasource=github-releases depName=clj-kondo/clj-kondo versioning=loose
           clj-kondo: '2026.05.25'
           # renovate: datasource=github-releases depName=greglook/cljstyle

--- a/sources/github-actions/workflows/clojurescript.yml
+++ b/sources/github-actions/workflows/clojurescript.yml
@@ -49,7 +49,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           # renovate: datasource=github-releases depName=technomancy/leiningen
-          lein: '2.13.0'
+          lein: '2.12.0'
           # renovate: datasource=github-releases depName=clj-kondo/clj-kondo versioning=loose
           clj-kondo: '2026.05.25'
           # renovate: datasource=github-releases depName=greglook/cljstyle

--- a/sources/github-actions/workflows/deploy_to_clojars.yml
+++ b/sources/github-actions/workflows/deploy_to_clojars.yml
@@ -48,7 +48,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           # renovate: datasource=github-releases depName=technomancy/leiningen
-          lein: '2.13.0'
+          lein: '2.12.0'
           # renovate: datasource=github-releases depName=clj-kondo/clj-kondo versioning=loose
           clj-kondo: '2026.05.25'
           # renovate: datasource=github-releases depName=greglook/cljstyle

--- a/sources/github-actions/workflows/format.yml
+++ b/sources/github-actions/workflows/format.yml
@@ -52,7 +52,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           # renovate: datasource=github-releases depName=technomancy/leiningen
-          lein: '2.13.0'
+          lein: '2.12.0'
           # renovate: datasource=github-releases depName=clj-kondo/clj-kondo versioning=loose
           clj-kondo: '2026.05.25'
           # renovate: datasource=github-releases depName=greglook/cljstyle

--- a/sources/github-actions/workflows/lint.yml
+++ b/sources/github-actions/workflows/lint.yml
@@ -140,7 +140,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           # renovate: datasource=github-releases depName=technomancy/leiningen
-          lein: '2.13.0'
+          lein: '2.12.0'
           # renovate: datasource=github-releases depName=clj-kondo/clj-kondo versioning=loose
           clj-kondo: '2026.05.25'
           # renovate: datasource=github-releases depName=greglook/cljstyle
@@ -213,7 +213,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           # renovate: datasource=github-releases depName=technomancy/leiningen
-          lein: '2.13.0'
+          lein: '2.12.0'
           # renovate: datasource=github-releases depName=clj-kondo/clj-kondo versioning=loose
           clj-kondo: '2026.05.25'
           # renovate: datasource=github-releases depName=greglook/cljstyle


### PR DESCRIPTION
Reverts Wall-Brew-Co/rebroadcast#113 - The current state of this action is broken for leiningen 2.13.0